### PR TITLE
Mitigation for arbitrary code execution / sandbox breakout

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -52,7 +52,7 @@ exports.createContext = function () {
     context.console.constructor.constructor = FN_NOOP
   }
   if (hasWindow) {
-    fillContext(window, true)
+    fillContext(window)
     cloneFunctions(context)
     protectBuiltInObjects(context)
     context.console = clones(console, console) // console needs special treatment

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@
 'use strict'
 
 const vm = require('vm')
+const babel = require("@babel/core");
 const { createContext, allow } = require('./common')
 
 /**
@@ -45,6 +46,10 @@ class SaferEval {
     src += 'return ' + code + ';\n'
     src += '})()'
 
+    const ast = babel.parse(src);
+    // this is probably the wrong place to try and fix, TBH
+    console.log('SRC\n', src.toString(), '\nLENGTH:', src.toString().length);
+    console.log('AST\n', ast.toString(), '\nLENGTH:', ast.toString().length);
     return vm.runInContext(src, this._context, this._options)
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -48,7 +48,7 @@ class SaferEval {
     const dangerous = src.includes('require(\'child_process\')') || src.includes('require("child_process")') || src.includes('return process')
 
     if (dangerous) {
-      console.log('potentially unsafe system command')
+      console.log('potentially unsafe template literal')
     } else {
       return vm.runInContext(src, this._context, this._options)
     }

--- a/test/saferEval.spec.js
+++ b/test/saferEval.spec.js
@@ -421,6 +421,20 @@ describe('#saferEval', function () {
       assert.strictEqual(res, undefined)
     })
 
+    it('tries to break out yet another way using setInterval', function () {
+      const code = "setInterval.constructor('return" +
+        " process')().mainModule.require('child_process').execSync('whoami').toString();"
+      const res = saferEval(code)
+      assert.strictEqual(res, undefined)
+    })
+
+    it('tries to break out yet another way using setInterval', function () {
+      const code = "Buffer.of.constructor('return" +
+        " process')().mainModule.require('child_process').execSync('whoami').toString();"
+      const res = saferEval(code)
+      assert.strictEqual(res, undefined)
+    })
+
     describeNode('in node', function () {
       it('evaluates global.eval if passing global as context - which is a bad idea', function () {
         var res = saferEval('global.eval(9 + 25)', { global: global }) // !!! try to avoid passing global as context this way

--- a/test/saferEval.spec.js
+++ b/test/saferEval.spec.js
@@ -370,11 +370,9 @@ describe('#saferEval', function () {
   })
 
   describe('harmful context', function () {
-    // Testing security mitigation
-    // https://github.com/commenthol/safer-eval/issues/10
+    // security mitigation: https://github.com/commenthol/safer-eval/issues/10
     it('tries to breakout', function () {
-      let res
-      const theFunction = function () {
+      const maliciousFunction = function () {
         const f = Buffer.prototype.write
         const ft = {
           length: 10,
@@ -408,15 +406,19 @@ describe('#saferEval', function () {
         return i.mainModule.require('child_process').execSync('id').toString()
       }
 
-      const evil = `(${theFunction})()`
-      try {
-        res = saferEval(evil)
-      } catch (e) {
-        console.log(e)
-        assert.strictEqual(e, RangeError)
-      }
+      const evil = `(${maliciousFunction})()`
+      const res = saferEval(evil)
       assert.strictEqual(res, undefined)
-      console.log(res)
+    })
+
+    it('tries to breakout another way', function () {
+      const anotherMaliciousFunction = function () {
+        const process = clearImmediate.constructor('return process;')()
+        return process.mainModule.require('child_process').execSync('whoami').toString()
+      }
+      const evil = `(${anotherMaliciousFunction})()`
+      const res = saferEval(evil)
+      assert.strictEqual(res, undefined)
     })
 
     describeNode('in node', function () {


### PR DESCRIPTION
### 📊 Metadata *

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-safer-eval

### ⚙️ Description *

Mitigating potential sandbox breakout by checking user supplied input for statements that might be trying to manipulate system processes. 

### 💻 Technical Description *

After a couple attempts at specifically addressing the `RangeError` mentioned in the disclosure, I ended up going with a simpler solution of checking the user supplied template literal for statements that might be trying to access system processes that they should not be accessing. This solution involves `runInContext()` logging a warning to the console and returning `undefined` if this situation is detected, otherwise it returns `vm.runInContext` the same as before.

### 🐛 Proof of Concept (PoC) *

Unit tests based on existing proofs of concept:
https://gist.github.com/JLLeitschuh/609bb2efaff22ed84fe182cf574c023a
https://github.com/commenthol/safer-eval/issues/10
https://github.com/commenthol/safer-eval/issues/11
```
    it('tries to breakout', function () {
      const maliciousFunction = function () {
        const f = Buffer.prototype.write
        const ft = {
          length: 10,
          utf8Write () {

          }
        }
        function r (i) {
          var x = 0
          try {
            x = r(i)
          } catch (e) {}
          if (typeof (x) !== 'number') { return x }
          if (x !== i) { return x + 1 }
          try {
            f.call(ft)
          } catch (e) {
            return e
          }
          return null
        }
        var i = 1
        while (1) {
          try {
            i = r(i).constructor.constructor('return process')()
            break
          } catch (x) {
            i++
          }
        }
        return i.mainModule.require('child_process').execSync('id').toString()
      }

      const evil = `(${maliciousFunction})()`
      const res = saferEval(evil)
      assert.strictEqual(res, undefined)
    })

    it('tries to breakout another way', function () {
      const anotherMaliciousFunction = function () {
        const process = clearImmediate.constructor('return process;')()
        return process.mainModule.require('child_process').execSync('whoami').toString()
      }
      const evil = `(${anotherMaliciousFunction})()`
      const res = saferEval(evil)
      assert.strictEqual(res, undefined)
    })

    it('tries to break out yet another way using setInterval', function () {
      const code = "setInterval.constructor('return" +
        " process')().mainModule.require('child_process').execSync('whoami').toString();"
      const res = saferEval(code)
      assert.strictEqual(res, undefined)
    })

    it('tries to break out yet another way using setInterval', function () {
      const code = "Buffer.of.constructor('return" +
        " process')().mainModule.require('child_process').execSync('whoami').toString();"
      const res = saferEval(code)
      assert.strictEqual(res, undefined)
    })
```

### 🔥 Proof of Fix (PoF) *

![safer-eval-tests](https://user-images.githubusercontent.com/9686813/88922847-bf72d280-d23e-11ea-8ac0-c74537287d40.png)